### PR TITLE
Fix invalid reference of local variable config

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -76,7 +76,7 @@ module Danger
       markdown(report_markdown)
 
       # Notify failure if minimum coverage hasn't been reached
-      threshold = config[:minimum_coverage_percentage].to_i
+      threshold = Xcov.config[:minimum_coverage_percentage].to_i
       if !threshold.nil? && (report.coverage * 100) < threshold
         fail("Code coverage under minimum of #{threshold}%")
       end


### PR DESCRIPTION
Referencing `config` is not resolved while separating generation and output report.