### PR TITLE
To generate a local report by running the 'run' method from the Xcov::Manager

### DIFF
--- a/danger-xcov.gemspec
+++ b/danger-xcov.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ['lib']
 
   spec.add_dependency 'danger', '>= 2.1'
-  spec.add_dependency 'xcov', '>= 1.1.2'
+  spec.add_dependency 'xcov', '>= 1.7.3'
   spec.add_development_dependency 'bundler', '~> 1.3'
   spec.add_development_dependency 'rake'
 end

--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -58,10 +58,16 @@ module Danger
       Xcov.ignore_handler = Xcov::IgnoreHandler.new
 
       # Init project
-      manager =  Xcov::Manager.new(config)
+      report_json = nil
+      manager = Xcov::Manager.new(config)
 
-      # Parse .xccoverage
-      report_json = manager.parse_xccoverage
+      if Xcov.config[:html_report] || Xcov.config[:markdown_report] || Xcov.config[:json_report]
+        # Parse .xccoverage and create local report
+        report_json = manager.run
+      else
+        # Parse .xccoverage
+        report_json = manager.parse_xccoverage
+      end
 
       # Map and process report
       process_report(Xcov::Report.map(report_json))

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,4 +1,4 @@
 module DangerXcov
-  VERSION = "0.4.1"
+  VERSION = "0.5.0"
   DESCRIPTION = "Danger plugin to validate the code coverage of the files changed"
 end


### PR DESCRIPTION
Ability to generate local reports json, markdown or html format) directly from the danger-xcov plugin that uses xcov

The following PR have to be merged to get the json_report value from the 'run' method of xcov  : https://github.com/fastlane-community/xcov/pull/154