### PR TITLE
fixed file filtration

### DIFF
--- a/lib/danger_plugin.rb
+++ b/lib/danger_plugin.rb
@@ -91,10 +91,10 @@ module Danger
 
     # Filters the files that haven't been modified in the current PR
     def process_report(report)
-      file_names = @dangerfile.git.modified_files.map { |file| File.basename(file) }
-      file_names += @dangerfile.git.added_files.map { |file| File.basename(file) }
+      file_names = @dangerfile.git.modified_files.map { |file| File.expand_path(file) }
+      file_names += @dangerfile.git.added_files.map { |file| File.expand_path(file) }
       report.targets.each do |target|
-        target.files = target.files.select { |file| file_names.include?(file.name) }
+        target.files = target.files.select { |file| file_names.include?(file.location) }
       end
 
       report


### PR DESCRIPTION
I've noticed that when you have multiple files with same name in different modules, when changing or adding one, report contains all of them (even if you didn't touch them), this fix should help filter files correctly 🙂